### PR TITLE
Added AdvertisementWatcher property to WindowsBluetoothPacketProvider…

### DIFF
--- a/Library/UniversalBeacon.Library.Android/AndroidBluetoothPacketProvider.cs
+++ b/Library/UniversalBeacon.Library.Android/AndroidBluetoothPacketProvider.cs
@@ -28,15 +28,8 @@ namespace UniversalBeacon.Library
 
         public void Start()
         {
-            //try
-            //{
-                _scanCallback.OnAdvertisementPacketReceived += ScanCallback_OnAdvertisementPacketReceived;
-                _adapter.BluetoothLeScanner.StartScan(_scanCallback);
-            //}
-            //catch (Exception)
-            //{
-            //    // TODO
-            //}
+            _scanCallback.OnAdvertisementPacketReceived += ScanCallback_OnAdvertisementPacketReceived;
+            _adapter.BluetoothLeScanner.StartScan(_scanCallback);
         }
 
         public void Stop()


### PR DESCRIPTION
Provides access to the Windows BLE Advertisement watcher to allow consumers to set properties like filters.  Only concern here is that it also provides an indirect way to start and stop the watcher beneath the PacketProvider.  I guess if a consumer is starting and stopping it manually, it's on them to make sure it tracks state.