### PR TITLE
Ignore .DS_Store on Mac OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,7 @@ FakesAssemblies/
 /WindowsBeacons/Package.StoreAssociation.xml
 /Samples/WindowsBeacons/BundleArtifacts
 /Samples/WindowsBeacons/Package.StoreAssociation.xml
+
+# OS X
+.DS_Store
+


### PR DESCRIPTION
Updated  `.gitignore` to skip `.DS_Store` files on Mac OS X.
No functional changes to the library.